### PR TITLE
Change muted attribute for autoplay working on chrome

### DIFF
--- a/responsive-video-background.js
+++ b/responsive-video-background.js
@@ -82,7 +82,7 @@ export class ResponsiveVideoBackground extends HTMLElement {
 
         videoElement.setAttribute('playsinline', '');
         videoElement.setAttribute('no-controls', '');
-        videoElement.setAttribute('muted', '');
+        videoElement.muted = true;
         videoElement.setAttribute('loop', '');
 
         if ('autoplay' in options && options.autoplay) {


### PR DESCRIPTION
On chrome, the autoplay dosen't work if video is injected by script (web component shodwRoot or classic JS).
It seems we need to change the way the `muted` is set to make it work.